### PR TITLE
add .env and .env.user file support and tests

### DIFF
--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,2 @@
+#comment
+set-env-smoke-test-env-set=test

--- a/tests/.env.user
+++ b/tests/.env.user
@@ -1,0 +1,2 @@
+#comment
+set-env-smoke-test-env-user-set=test

--- a/tests/Set-Env.Tests.ps1
+++ b/tests/Set-Env.Tests.ps1
@@ -1,0 +1,58 @@
+Describe 'Module Tests' {
+    #$repoPath = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    #$ModuleName = Split-Path $repoPath -Leaf
+    #$ModuleScriptName = "$ModuleName.psm1"
+    #$ModuleScriptPath = "$repoPath\src\$ModuleName\$ModuleScriptName"
+
+    It 'imports successfully' {
+        $repoPath = Split-Path $PSScriptRoot -Parent
+        $ModuleName = Split-Path $repoPath -Leaf
+        #$ModuleScriptPath = "$repoPath\src\$ModuleName\$ModuleName.psm1"
+        $ModuleScriptPath = "$repoPath\$ModuleName\$ModuleName.psm1"
+
+        Write-Verbose "Import-Module -Name $($ModuleScriptPath)"
+        { Import-Module -Name $ModuleScriptPath -ErrorAction Stop } | Should -Not -Throw
+    }
+
+    It 'passes default PSScriptAnalyzer rules' {
+        $repoPath = Split-Path $PSScriptRoot -Parent
+        $ModuleName = Split-Path $repoPath -Leaf
+        $ModuleScriptPath = "$repoPath\$ModuleName\$ModuleName.psm1"
+        
+        #fairly certain, this is newly required, used to already be in:
+        #Install-Module PSScriptAnalyzer -Scope CurrentUser
+        Invoke-ScriptAnalyzer -Path $ModuleScriptPath | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Module Manifest Tests' {
+    It 'passes Test-ModuleManifest' {
+        $repoPath = Split-Path $PSScriptRoot -Parent
+        $ModuleName = Split-Path $repoPath -Leaf
+        $ModuleManifestName = "$ModuleName.psd1"
+        $ModuleManifestPath = "$repoPath\$ModuleName\$ModuleManifestName"
+
+        Write-Output $ModuleManifestPath
+        Test-ModuleManifest -Path $ModuleManifestPath | Should -Not -BeNullOrEmpty
+        $? | Should -Be $true
+    }
+}
+
+Describe 'Smoke Tests' {
+    It 'passes empty params' {
+        $results = Set-Env -Verbose | Should -Not -BeNullOrEmpty
+        Write-Verbose "results:$results"
+    }
+    It 'passes env set' {
+        [System.Environment]::SetEnvironmentVariable("set-env-smoke-test-env-set","x")
+        Set-Env -Verbose | Should -Not -BeNullOrEmpty
+        $results = (Get-Item 'env:set-env-smoke-test-env-set').value
+        $results | Should -Be 'test'
+    }    
+    It 'passes env-user set' {
+        [System.Environment]::SetEnvironmentVariable("set-env-smoke-test-env-user-set","x")
+        Set-Env -Verbose | Should -Not -BeNullOrEmpty
+        $results = (Get-Item 'env:set-env-smoke-test-env-user-set').value
+        $results | Should -Be 'test'
+    }
+}


### PR DESCRIPTION
It applies .env and .env.user file to env starting with PowerShell user profile home, Set-Env.ps1 folder and Get-Location
I added some Pester tests, execute/test like this:
invoke-pester .\set-env.tests.ps1 -output detailed -verbose
Fairly certain, all previous functionality still functions, this just adds new functionality.